### PR TITLE
PlaylistManager config loading support

### DIFF
--- a/BeatSaberCinema/BeatSaberCinema.csproj
+++ b/BeatSaberCinema/BeatSaberCinema.csproj
@@ -81,6 +81,10 @@
 		<Reference Include="Newtonsoft.Json">
 			<HintPath>$(BeatSaberDir)\IPA\Libs\Newtonsoft.Json.dll</HintPath>
 		</Reference>
+		<Reference Include="SemVer">
+			<SpecificVersion>False</SpecificVersion>
+			<HintPath>$(BeatSaberDir)\IPA\Libs\SemVer.dll</HintPath>
+		</Reference>
 		<Reference Include="Main">
 			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
 			<Private>False</Private>

--- a/BeatSaberCinema/BeatSaberCinema.csproj
+++ b/BeatSaberCinema/BeatSaberCinema.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-		<TargetFramework>net472</TargetFramework>
+		<TargetFramework>net48</TargetFramework>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <OutputType>Library</OutputType>
         <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -91,6 +91,14 @@
 		</Reference>
 		<Reference Include="BSML">
 			<HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="PlaylistManager">
+			<HintPath>$(BeatSaberDir)\Plugins\PlaylistManager.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="BeatSaberPlaylistsLib">
+			<HintPath>$(BeatSaberDir)\Libs\BeatSaberPlaylistsLib.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="HMLib">

--- a/BeatSaberCinema/Util/Util.cs
+++ b/BeatSaberCinema/Util/Util.cs
@@ -76,9 +76,9 @@ namespace BeatSaberCinema
 			return s;
 		}
 
-		public static bool IsModInstalled(string modName)
+		public static bool IsModInstalled(string modName, string? minimumVersion = null)
 		{
-			return IPA.Loader.PluginManager.EnabledPlugins.Any(x => x.Id == modName);
+			return IPA.Loader.PluginManager.EnabledPlugins.Any(x => x.Id == modName && (minimumVersion == null || x.Version >= new SemVer.Version(minimumVersion)));
 		}
 
 		public static Texture? LoadPNGFromResources(string resourcePath) {

--- a/BeatSaberCinema/Video/VideoLoader.cs
+++ b/BeatSaberCinema/Video/VideoLoader.cs
@@ -261,9 +261,9 @@ namespace BeatSaberCinema
 			return videoConfig;
 		}
 
-		public static VideoConfig? GetConfigForPlaylistSong(BeatSaberPlaylistsLib.Types.IPlaylistSong playlistSong)
+		public static VideoConfig? GetConfigForPlaylistSong(IPreviewBeatmapLevel previewBeatmapLevel)
 		{
-			if (playlistSong == null || playlistSong.PreviewBeatmapLevel == null)
+			if (!(previewBeatmapLevel is BeatSaberPlaylistsLib.Types.IPlaylistSong playlistSong) || playlistSong == null || playlistSong.PreviewBeatmapLevel == null)
 			{
 				Log.Debug($"PlaylistSong is null");
 				return null;
@@ -490,8 +490,13 @@ namespace BeatSaberCinema
 			return videoConfig;
 		}
 
-		private static VideoConfig? LoadConfigFromPlaylistSong(BeatSaberPlaylistsLib.Types.IPlaylistSong playlistSong, string levelPath)
+		private static VideoConfig? LoadConfigFromPlaylistSong(IPreviewBeatmapLevel previewBeatmapLevel, string levelPath)
 		{
+			if (!(previewBeatmapLevel is BeatSaberPlaylistsLib.Types.IPlaylistSong playlistSong))
+			{
+				return null;
+			}
+
 			if (playlistSong.TryGetCustomData("cinema", out var cinemaData))
 			{
 				VideoConfig? videoConfig;

--- a/BeatSaberCinema/VideoMenu/VideoMenu.cs
+++ b/BeatSaberCinema/VideoMenu/VideoMenu.cs
@@ -459,9 +459,9 @@ namespace BeatSaberCinema
 			_searchText = _currentLevel.songName + (!string.IsNullOrEmpty(_currentLevel.songAuthorName) ? " - " + _currentLevel.songAuthorName : "");
 		}
 
-		private void HandleDidSelectPlaylistSong(BeatSaberPlaylistsLib.Types.IPlaylistSong playlistSong)
+		private void HandleDidSelectPlaylistSong(IPreviewBeatmapLevel previewBeatmapLevel)
 		{
-			if (!Plugin.Enabled)
+			if (!Plugin.Enabled || !(previewBeatmapLevel is BeatSaberPlaylistsLib.Types.IPlaylistSong playlistSong))
 			{
 				return;
 			}


### PR DESCRIPTION
- Added PlaylistManager/BeatSaberPlaylistsLib as optional dependencies. .NET version bumped as a result.
- Subbed to PlaylistSong select, it is handled properly since there is a regular level select and PlaylistSong select. If PlaylistSong select happens after regular, it will use the playlist configs (assuming local ones are not availaible) and if regular song select event is raised after playlist, it wont overwrite the configs.
- Handled playlist configs as the way you suggested Local > Playlist > Bundled

Note: SubToPlaylistSong has to be in a different method, or it will exception out if PlaylistManager is not installed. That's why there is a weird one line method I had to make.

Feel free to message me on discord about any changes.