### PR TITLE
Improve editor support

### DIFF
--- a/BeatSaberCinema/Download/DownloadController.cs
+++ b/BeatSaberCinema/Download/DownloadController.cs
@@ -210,7 +210,7 @@ namespace BeatSaberCinema
 
 		private Process? CreateDownloadProcess(VideoConfig video, VideoQuality.Mode quality)
 		{
-			if (video.LevelDir == null)
+			if (video.LevelDir == null || video.VideoPath == null)
 			{
 				Log.Error("LevelDir was null during download");
 				return null;
@@ -221,13 +221,6 @@ namespace BeatSaberCinema
 			{
 				Log.Warn("Existing process not cleaned up yet. Cancelling download attempt.");
 				return null;
-			}
-
-			var path = Path.GetFileName(Path.GetDirectoryName(video.VideoPath));
-			if (video.VideoPath != null && path != null && !Directory.Exists(path))
-			{
-				//Needed for OST/WIP videos
-				Directory.CreateDirectory(path);
 			}
 
 			string videoUrl;

--- a/BeatSaberCinema/Download/DownloadController.cs
+++ b/BeatSaberCinema/Download/DownloadController.cs
@@ -223,15 +223,12 @@ namespace BeatSaberCinema
 				return null;
 			}
 
-			if (!Directory.Exists(video.LevelDir))
+			var path = Path.GetFileName(Path.GetDirectoryName(video.VideoPath));
+			if (video.VideoPath != null && path != null && !Directory.Exists(path))
 			{
-				//Needed for OST videos
-				Directory.CreateDirectory(video.LevelDir);
+				//Needed for OST/WIP videos
+				Directory.CreateDirectory(path);
 			}
-
-			var videoFileName = Util.ReplaceIllegalFilesystemChars(video.title ?? video.videoID ?? "video");
-			videoFileName = Util.ShortenFilename(video.LevelDir, videoFileName);
-			video.videoFile = videoFileName + ".mp4";
 
 			string videoUrl;
 			if (video.videoUrl != null)
@@ -262,7 +259,7 @@ namespace BeatSaberCinema
 			var downloadProcessArguments = videoUrl +
 			                               videoFormat +
 			                               " --no-cache-dir" + // Don't use temp storage
-			                               $" -o \"{videoFileName}.%(ext)s\"" +
+			                               $" -o \"{video.VideoPath}\"" +
 			                               " --no-playlist" + // Don't download playlists, only the first video
 			                               " --no-part" + // Don't store download in parts, write directly to file
 			                               " --recode-video mp4" + //Re-encode to mp4 (will be skipped most of the time, since it's already in an mp4 container)

--- a/BeatSaberCinema/Environment/EnvironmentController.cs
+++ b/BeatSaberCinema/Environment/EnvironmentController.cs
@@ -66,16 +66,14 @@ namespace BeatSaberCinema
 		private static void SceneChanged(Scene arg0, Scene arg1)
 		{
 			Log.Debug($"Scene changed from {arg0.name} to {arg1.name}");
-			for (var i = 0; i < SceneManager.sceneCount; i++)
+			var sceneName = arg1.name;
+			if (sceneName == "BeatmapLevelEditorWorldUi")
 			{
-				var sceneName = SceneManager.GetSceneAt(i).name;
-				if (sceneName == "BeatmapLevelEditorWorldUi")
-				{
-					PlaybackController.Instance.GameSceneLoaded();
-				}
+				Reset();
+				PlaybackController.Instance.GameSceneLoaded();
 			}
 
-			if (arg1.name == "MainMenu" || arg1.name == "PCInit")
+			if (sceneName == "MainMenu" || sceneName == "PCInit")
 			{
 				Reset();
 			}

--- a/BeatSaberCinema/Harmony/Patches/EditorPatches.cs
+++ b/BeatSaberCinema/Harmony/Patches/EditorPatches.cs
@@ -57,10 +57,12 @@ namespace BeatSaberCinema.Patches
 		[UsedImplicitly]
 		public static void Prefix(UpdatePlayHeadSignal ____signal, IBeatmapDataModel ____beatmapDataModel)
 		{
-			//TODO: This triggers not only during seek, but also just normal playback
-			var mapTime = AudioTimeHelper.SamplesToSeconds(____signal.sample, ____beatmapDataModel.audioClip.frequency);
-			PlaybackController.Instance.ResyncVideo(mapTime);
-			PlaybackController.Instance.VideoPlayer.UpdateScreenContent();
+			if (PlaybackController.Instance.VideoPlayer.IsPrepared && !PlaybackController.Instance.VideoPlayer.IsPlaying)
+			{
+				var mapTime = AudioTimeHelper.SamplesToSeconds(____signal.sample, ____beatmapDataModel.audioClip.frequency);
+				PlaybackController.Instance.ResyncVideo(mapTime);
+				PlaybackController.Instance.VideoPlayer.UpdateScreenContent();
+			}
 		}
 	}
 

--- a/BeatSaberCinema/Harmony/Patches/EditorPatches.cs
+++ b/BeatSaberCinema/Harmony/Patches/EditorPatches.cs
@@ -81,7 +81,6 @@ namespace BeatSaberCinema.Patches
 		[UsedImplicitly]
 		public static void Prefix()
 		{
-			PlaybackController.Instance.StopPlayback();
 			VideoLoader.StopFileSystemWatcher();
 		}
 	}
@@ -94,19 +93,13 @@ namespace BeatSaberCinema.Patches
 		{
 			if (PlaybackController.Instance.VideoConfig != null)
 			{
+				Log.Debug("Restoring config and fs watcher after editor save...", true);
 				var config = PlaybackController.Instance.VideoConfig;
 				config.NeedsToSave = true;
 				VideoLoader.SaveVideoConfig(config);
 				if (config.videoFile != null && config.VideoPath != null)
 				{
-					var path = Path.Combine(____lastBackup, config.videoFile);
-					if (File.Exists(path))
-					{
-						Log.Debug($"Moving {path} to {config.VideoPath}");
-						File.Move(path, config.VideoPath);
-						VideoLoader.SetupFileSystemWatcher(config.VideoPath);
-						PlaybackController.Instance.OnConfigChanged(config, true);
-					}
+					VideoLoader.SetupFileSystemWatcher(config.VideoPath);
 				}
 			}
 		}

--- a/BeatSaberCinema/Harmony/Patches/EditorPatches.cs
+++ b/BeatSaberCinema/Harmony/Patches/EditorPatches.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using BeatmapEditor.Commands;
+﻿using BeatmapEditor.Commands;
 using BeatmapEditor3D;
 using BeatmapEditor3D.BpmEditor;
 using BeatmapEditor3D.BpmEditor.Commands;
@@ -61,6 +60,7 @@ namespace BeatSaberCinema.Patches
 			//TODO: This triggers not only during seek, but also just normal playback
 			var mapTime = AudioTimeHelper.SamplesToSeconds(____signal.sample, ____beatmapDataModel.audioClip.frequency);
 			PlaybackController.Instance.ResyncVideo(mapTime);
+			PlaybackController.Instance.VideoPlayer.UpdateScreenContent();
 		}
 	}
 

--- a/BeatSaberCinema/Harmony/Patches/EditorPatches.cs
+++ b/BeatSaberCinema/Harmony/Patches/EditorPatches.cs
@@ -47,7 +47,7 @@ namespace BeatSaberCinema.Patches
 		public static void Prefix(SetPlayHeadSignal ____signal, BpmEditorSongPreviewController ____bpmEditorSongPreviewController)
 		{
 			var mapTime = AudioTimeHelper.SamplesToSeconds(____signal.sample, ____bpmEditorSongPreviewController.audioClip.frequency);
-			PlaybackController.Instance.ResyncVideo(mapTime);
+			PlaybackController.Instance.ResyncVideo(mapTime != 0 ? mapTime : (float?) null);
 		}
 	}
 
@@ -60,7 +60,7 @@ namespace BeatSaberCinema.Patches
 			if (PlaybackController.Instance.VideoPlayer.IsPrepared && !PlaybackController.Instance.VideoPlayer.IsPlaying)
 			{
 				var mapTime = AudioTimeHelper.SamplesToSeconds(____signal.sample, ____beatmapDataModel.audioClip.frequency);
-				PlaybackController.Instance.ResyncVideo(mapTime);
+				PlaybackController.Instance.ResyncVideo(mapTime != 0 ? mapTime : (float?) null);
 				PlaybackController.Instance.VideoPlayer.UpdateScreenContent();
 			}
 		}

--- a/BeatSaberCinema/Screen/CustomVideoPlayer.cs
+++ b/BeatSaberCinema/Screen/CustomVideoPlayer.cs
@@ -327,7 +327,7 @@ namespace BeatSaberCinema
 
 		private void Update()
 		{
-			if (Player.isPlaying)
+			if (Player.isPlaying || (Player.isPrepared && Player.isPaused))
 			{
 				SetTexture(Player.texture);
 			}

--- a/BeatSaberCinema/Screen/CustomVideoPlayer.cs
+++ b/BeatSaberCinema/Screen/CustomVideoPlayer.cs
@@ -297,9 +297,15 @@ namespace BeatSaberCinema
 
 		public void Play()
 		{
+			if (_firstFrameStopwatch.IsRunning)
+			{
+				return;
+			}
+
 			Log.Debug("Starting playback, waiting for first frame...");
 			_waitingForFadeOut = false;
 			_firstFrameStopwatch.Start();
+			Player.frameReady -= FirstFrameReady;
 			Player.frameReady += FirstFrameReady;
 			Player.Play();
 		}
@@ -307,6 +313,7 @@ namespace BeatSaberCinema
 		public void Pause()
 		{
 			Player.Pause();
+			_firstFrameStopwatch.Reset();
 		}
 
 		public void Stop()
@@ -316,6 +323,7 @@ namespace BeatSaberCinema
 			stopped?.Invoke();
 			SetStaticTexture(null);
 			screenController.SetScreensActive(false);
+			_firstFrameStopwatch.Reset();
 		}
 
 		public void Prepare()

--- a/BeatSaberCinema/Screen/PlaybackController.cs
+++ b/BeatSaberCinema/Screen/PlaybackController.cs
@@ -685,7 +685,7 @@ namespace BeatSaberCinema
 			{
 				Log.Debug("Waiting for ATSC to be ready");
 
-				if (Util.IsInEditor())
+				if (Util.IsInEditor() && SceneManager.GetActiveScene().name != "GameCore")
 				{
 					//_editorTimeSyncController = Resources.FindObjectsOfTypeAll<BeatmapEditorAudioTimeSyncController>().FirstOrDefault(atsc => atsc.name == "BeatmapEditorAudioTimeSyncController");
 					_activeAudioSource = Resources.FindObjectsOfTypeAll<AudioSource>()

--- a/BeatSaberCinema/Video/VideoConfig.cs
+++ b/BeatSaberCinema/Video/VideoConfig.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
+using SongCore.Data;
 using UnityEngine;
 
 // ReSharper disable InconsistentNaming
@@ -104,7 +106,12 @@ namespace BeatSaberCinema
 		[JsonIgnore] public bool IsStreamable => videoFile != null && (videoFile.StartsWith("http://") || videoFile.StartsWith("https://"));
 		[JsonIgnore] public bool IsLocal => videoFile != null && !IsStreamable;
 		[JsonIgnore] public bool IsPlayable => (DownloadState == DownloadState.Downloaded || IsStreamable) && !PlaybackDisabledByMissingSuggestion;
-		[JsonIgnore] public bool IsWIPLevel => LevelDir != null && LevelDir.Contains(VideoLoader.WIP_MAPS_FOLDER);
+		[JsonIgnore] public bool IsWIPLevel =>
+			LevelDir != null &&
+			(LevelDir.Contains(VideoLoader.WIP_MAPS_FOLDER) ||
+			 SongCore.Loader.SeperateSongFolders.Any(folder => (folder.SongFolderEntry.Pack == FolderLevelPack.CustomWIPLevels || folder.SongFolderEntry.WIP) && LevelDir.Contains(folder.SongFolderEntry.Name))
+			);
+
 		[JsonIgnore] public bool EnvironmentModified => (environment != null && environment.Length > 0) || screenPosition != null || screenHeight != null;
 		[JsonIgnore] public float PlaybackSpeed => playbackSpeed ?? 1;
 

--- a/BeatSaberCinema/Video/VideoConfig.cs
+++ b/BeatSaberCinema/Video/VideoConfig.cs
@@ -66,11 +66,23 @@ namespace BeatSaberCinema
 		{
 			get
 			{
-				if (videoFile != null && IsLocal && LevelDir != null)
+				if (LevelDir != null && LevelDir.Contains(VideoLoader.WIP_MAPS_FOLDER))
+				{
+					var path = Path.Combine(
+						Environment.CurrentDirectory,
+						"Beat Saber_Data",
+						VideoLoader.WIP_MAPS_FOLDER,
+						VideoLoader.WIP_DIRECTORY_NAME,
+						videoFile
+					);
+					return path;
+				}
+
+				if (IsLocal && LevelDir != null)
 				{
 					try
 					{
-						return Path.Combine(LevelDir, videoFile);
+						return Path.Combine(LevelDir, videoFile!);
 					}
 					catch (Exception e)
 					{
@@ -79,11 +91,12 @@ namespace BeatSaberCinema
 					}
 				}
 
-				if (videoFile != null && IsStreamable)
+				if (IsStreamable)
 				{
 					return videoFile;
 				}
 
+				Log.Debug("VideoPath is null");
 				return null;
 			}
 		}
@@ -91,7 +104,7 @@ namespace BeatSaberCinema
 		[JsonIgnore] public bool IsStreamable => videoFile != null && (videoFile.StartsWith("http://") || videoFile.StartsWith("https://"));
 		[JsonIgnore] public bool IsLocal => videoFile != null && !IsStreamable;
 		[JsonIgnore] public bool IsPlayable => (DownloadState == DownloadState.Downloaded || IsStreamable) && !PlaybackDisabledByMissingSuggestion;
-		[JsonIgnore] public bool IsWIPLevel => LevelDir != null && LevelDir.Contains(VideoLoader.WIP_DIRECTORY_NAME);
+		[JsonIgnore] public bool IsWIPLevel => LevelDir != null && LevelDir.Contains(VideoLoader.WIP_MAPS_FOLDER);
 		[JsonIgnore] public bool EnvironmentModified => (environment != null && environment.Length > 0) || screenPosition != null || screenHeight != null;
 		[JsonIgnore] public float PlaybackSpeed => playbackSpeed ?? 1;
 
@@ -149,6 +162,8 @@ namespace BeatSaberCinema
 			duration = searchResult.Duration;
 
 			LevelDir = levelPath;
+			videoFile = Util.ReplaceIllegalFilesystemChars(title ?? videoID ?? "video") + ".mp4";
+			videoFile = Util.ShortenFilename(VideoPath!, videoFile);
 		}
 
 		public new string ToString()

--- a/BeatSaberCinema/Video/VideoConfig.cs
+++ b/BeatSaberCinema/Video/VideoConfig.cs
@@ -102,6 +102,8 @@ namespace BeatSaberCinema
 			}
 		}
 
+		[JsonIgnore] public string? ConfigPath => LevelDir != null ? VideoLoader.GetConfigPath(LevelDir) : null;
+
 		[JsonIgnore] public bool IsStreamable => videoFile != null && (videoFile.StartsWith("http://") || videoFile.StartsWith("https://"));
 		[JsonIgnore] public bool IsLocal => videoFile != null && !IsStreamable;
 		[JsonIgnore] public bool IsPlayable => (DownloadState == DownloadState.Downloaded || IsStreamable) && !PlaybackDisabledByMissingSuggestion;

--- a/BeatSaberCinema/Video/VideoLoader.cs
+++ b/BeatSaberCinema/Video/VideoLoader.cs
@@ -21,7 +21,8 @@ namespace BeatSaberCinema
 	public static class VideoLoader
 	{
 		private const string OST_DIRECTORY_NAME = "CinemaOSTVideos";
-		internal const string WIP_DIRECTORY_NAME = "CustomWIPLevels";
+		internal const string WIP_DIRECTORY_NAME = "CinemaWIPVideos";
+		internal const string WIP_MAPS_FOLDER = "CustomWIPLevels";
 		private const string CONFIG_FILENAME = "cinema-video.json";
 		private const string CONFIG_FILENAME_MVP = "video.json";
 		private const string MOD_ID_MVP = "Music Video Player";

--- a/BeatSaberCinema/VideoMenu/VideoMenu.cs
+++ b/BeatSaberCinema/VideoMenu/VideoMenu.cs
@@ -546,7 +546,7 @@ namespace BeatSaberCinema
 				VideoLoader.SaveVideoConfig(_currentVideo);
 			}
 
-			_currentVideo = VideoLoader.GetConfigForLevel(beatmapData, originalPath);
+			_currentVideo = VideoLoader.GetConfigForEditorLevel(beatmapData, originalPath);
 			VideoLoader.SetupFileSystemWatcher(originalPath);
 			PlaybackController.Instance.SetSelectedLevel(null, _currentVideo);
 		}


### PR DESCRIPTION
Works around issue where video file remains locked after stopping the video player, causing save operations in the editor to fail intermittently.
Additionally fixes issues with test play and adds support for additional SongCore WIP folders