### PR TITLE
Updates and fixes for Beat Saber 1.39.0

### DIFF
--- a/BeatSaberCinema/BeatSaberCinema.csproj
+++ b/BeatSaberCinema/BeatSaberCinema.csproj
@@ -36,7 +36,11 @@
 		<Reference Include="AdditionalContentModel.Interfaces" Publicize="true">
 			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\AdditionalContentModel.Interfaces.dll</HintPath>
 		</Reference>
-		<Reference Include="BeatmapCore" Publicize="true">
+        <Reference Include="BeatSaber.BeatmapEditor" Publicize="true">
+            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.BeatmapEditor.dll</HintPath>
+            <Private>false</Private>
+        </Reference>
+        <Reference Include="BeatmapCore" Publicize="true">
 			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
 			<Private>False</Private>
 		</Reference>

--- a/BeatSaberCinema/Environment/EnvironmentController.cs
+++ b/BeatSaberCinema/Environment/EnvironmentController.cs
@@ -161,7 +161,7 @@ namespace BeatSaberCinema
 				PlaybackController.Instance.VideoPlayer.screenController.Screens.RemoveRange(1, PlaybackController.Instance.VideoPlayer.screenController.Screens.Count - 1);
 
 
-				if (Util.IsModInstalled("_Heck"))
+				if (InstalledMods.Heck)
 				{
 					var types = new[] {"Chroma.GameObjectTrackController", "Chroma.Lighting.EnvironmentEnhancement.GameObjectTrackController"};
 

--- a/BeatSaberCinema/Harmony/Patches/WaitForChromaPatch.cs
+++ b/BeatSaberCinema/Harmony/Patches/WaitForChromaPatch.cs
@@ -28,14 +28,7 @@ namespace BeatSaberCinema.Patches
 
 			//Turns out CustomPlatforms runs even later and undoes some of the scene modifications Cinema does. Waiting for a specific duration is more of a temporary fix.
 			//TODO Find a better way to implement this. The problematic coroutine in CustomPlatforms is CustomFloorPlugin.EnvironmentHider+<InternalHideObjectsForPlatform>
-			if (Util.IsModInstalled("CustomPlatforms"))
-			{
-				yield return new WaitForSeconds(0.75f);
-			}
-			else
-			{
-				yield return new WaitForSeconds(0.05f);
-			}
+			yield return new WaitForSeconds(InstalledMods.CustomPlatforms ? 0.75f : 0.05f);
 
 			EnvironmentController.ModifyGameScene(PlaybackController.Instance.VideoConfig);
 		}

--- a/BeatSaberCinema/Plugin.cs
+++ b/BeatSaberCinema/Plugin.cs
@@ -50,14 +50,16 @@ namespace BeatSaberCinema
 		private static void OnMenuSceneLoadedFresh(ScenesTransitionSetupDataSO scenesTransition)
 		{
 			PlaybackController.Create();
+
+			if (VideoMenu.Instance != null)
+			{
+				VideoMenu.RemoveTab();
+			}
 			VideoMenu.AddTab();
+
 			SettingsUI.CreateMenu();
 			SongPreviewPlayerController.Init();
-
-			if (Util.IsModInstalled("BetterSongList", "0.3.2") && !_filterAdded)
-			{
-				AddBetterSongListFilter();
-			}
+			AddBetterSongListFilter();
 		}
 
 		[OnEnable]
@@ -76,7 +78,7 @@ namespace BeatSaberCinema
 			}
 
 			//No need to index maps if the filter isn't going to be applied anyway
-			if (Util.IsModInstalled("BetterSongList", "0.3.2"))
+			if (InstalledMods.BetterSongList)
 			{
 				Loader.SongsLoadedEvent += VideoLoader.IndexMaps;
 			}
@@ -96,7 +98,7 @@ namespace BeatSaberCinema
 			//TODO Destroying and re-creating the PlaybackController messes up the VideoMenu without any exceptions in the log. Investigate.
 			//PlaybackController.Destroy();
 
-			VideoMenu.Instance?.RemoveTab();
+			VideoMenu.RemoveTab();
 			EnvironmentController.Disable();
 			VideoLoader.StopFileSystemWatcher();
 			Collections.DeregisterCapability(CAPABILITY);
@@ -114,13 +116,16 @@ namespace BeatSaberCinema
 
 		private static void AddBetterSongListFilter()
 		{
-			var filter = new HasVideoFilter();
-			var success = BetterSongList.FilterMethods.Register(filter);
-			if (success)
+			if (!InstalledMods.BetterSongList || _filterAdded)
 			{
-				_filterAdded = true;
-				Log.Debug($"Registered {nameof(HasVideoFilter)}");
+				return;
+			}
 
+			_filterAdded = BetterSongList.FilterMethods.Register(new HasVideoFilter());
+
+			if (_filterAdded)
+			{
+				Log.Debug($"Registered {nameof(HasVideoFilter)}");
 			}
 			else
 			{

--- a/BeatSaberCinema/Util/InstalledMods.cs
+++ b/BeatSaberCinema/Util/InstalledMods.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using IPA.Loader;
+using HiveVersion = Hive.Versioning.Version;
+
+namespace BeatSaberCinema
+{
+	/// <summary>
+	/// Declares a set of soft dependencies by whether they are installed.
+	///	true: is installed / false: is not installed
+	/// </summary>
+	internal static class InstalledMods
+	{
+		public static bool BetterSongList { get; } = IsModInstalled("BetterSongList", "0.3.2");
+		public static bool BeatSaberPlaylistsLib { get; } = IsModInstalled("BeatSaberPlaylistsLib", "1.7.0");
+		public static bool CustomPlatforms { get; } = IsModInstalled("CustomPlatforms");
+		public static bool MusicVideoPlayer { get; } = IsModInstalled("Music Video Player");
+		public static bool Heck { get; } = IsModInstalled("_Heck");
+
+		private static bool IsModInstalled(string modId, string? minimumVersion = null)
+		{
+			return minimumVersion == null ? PluginManager.EnabledPlugins.Any(x => x.Id == modId)
+				: PluginManager.EnabledPlugins.Any(x => x.Id == modId && x.HVersion >= new HiveVersion(minimumVersion));
+		}
+	}
+}

--- a/BeatSaberCinema/Util/PlaylistSongUtils.cs
+++ b/BeatSaberCinema/Util/PlaylistSongUtils.cs
@@ -1,0 +1,69 @@
+using System;
+using BeatSaberPlaylistsLib.Types;
+using Newtonsoft.Json;
+
+namespace BeatSaberCinema
+{
+	public static class PlaylistSongUtils
+	{
+		/// <summary>
+		/// Do not call this method without checking if BeatSaberPlaylistsLib is installed with <see cref="InstalledMods"/>
+		/// </summary>
+		public static bool IsPlaylistLevel(this BeatmapLevel? beatmapLevel)
+		{
+			return beatmapLevel is PlaylistLevel;
+		}
+
+		/// <summary>
+		/// Do not call this method without checking if BeatSaberPlaylistsLib is installed with <see cref="InstalledMods"/>
+		/// </summary>
+		public static BeatmapLevel? GetLevelFromPlaylistIfAvailable(this BeatmapLevel? beatmapLevel)
+		{
+			return beatmapLevel is PlaylistLevel playlistLevel ? playlistLevel.playlistSong.BeatmapLevel ?? beatmapLevel : beatmapLevel;
+		}
+
+		/// <summary>
+		/// Do not call this method without checking if BeatSaberPlaylistsLib is installed with <see cref="InstalledMods"/>
+		/// </summary>
+		public static bool TryGetPlaylistLevelConfig(this BeatmapLevel? beatmapLevel, string levelPath, out VideoConfig? videoConfig)
+		{
+			return (videoConfig = beatmapLevel is PlaylistLevel playlistLevel ? playlistLevel.TryLoadConfig(levelPath) : null) != null;
+		}
+
+		/// <summary>
+		/// Do not call this method without checking if BeatSaberPlaylistsLib is installed with <see cref="InstalledMods"/>
+		/// </summary>
+		public static VideoConfig? TryLoadConfig(this PlaylistLevel playlistLevel, string levelPath)
+		{
+			var playlistSong = playlistLevel.playlistSong;
+			if (playlistSong.TryGetCustomData("cinema", out var cinemaData))
+			{
+				VideoConfig? videoConfig;
+				try
+				{
+					var json = JsonConvert.SerializeObject(cinemaData);
+					videoConfig = JsonConvert.DeserializeObject<VideoConfig>(json);
+				}
+				catch (Exception e)
+				{
+					Log.Error($"Error parsing video json {playlistSong.Name}:");
+					Log.Error(e);
+					return null;
+				}
+
+				if (videoConfig == null)
+				{
+					Log.Warn($"Deserializing video config for {playlistSong.Name} failed");
+					return null;
+				}
+				videoConfig.LevelDir = levelPath;
+				videoConfig.UpdateDownloadState();
+
+				return videoConfig;
+			}
+
+			Log.Error($"No config exists for {playlistSong.Name}:");
+			return null;
+		}
+	}
+}

--- a/BeatSaberCinema/Util/Util.cs
+++ b/BeatSaberCinema/Util/Util.cs
@@ -79,11 +79,6 @@ namespace BeatSaberCinema
 			return s;
 		}
 
-		public static bool IsModInstalled(string modName, string? minimumVersion = null)
-		{
-			return IPA.Loader.PluginManager.EnabledPlugins.Any(x => x.Id == modName && (minimumVersion == null || x.HVersion >= new Hive.Versioning.Version(minimumVersion)));
-		}
-
 		public static Texture? LoadPNGFromResources(string resourcePath)
 		{
 			var fileData = BeatSaberMarkupLanguage.Utilities.GetResource(Assembly.GetExecutingAssembly(), resourcePath);

--- a/BeatSaberCinema/VideoMenu/VideoMenu.cs
+++ b/BeatSaberCinema/VideoMenu/VideoMenu.cs
@@ -7,7 +7,6 @@ using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.GameplaySetup;
 using BeatSaberMarkupLanguage.Parser;
-using BeatSaberPlaylistsLib.Types;
 using HMUI;
 using IPA.Utilities;
 using JetBrains.Annotations;
@@ -165,10 +164,11 @@ namespace BeatSaberCinema
 			GameplaySetup.Instance.AddTab("Cinema", "BeatSaberCinema.VideoMenu.Views.video-menu.bsml", Instance, MenuType.All);
 		}
 
-		public void RemoveTab()
+		public static void RemoveTab()
 		{
 			Log.Debug("Removing tab");
 			GameplaySetup.Instance.RemoveTab("Cinema");
+			Instance = null;
 		}
 
 		public void ResetVideoMenu()
@@ -548,12 +548,10 @@ namespace BeatSaberCinema
 				return;
 			}
 
-			var isPlaylistSong = level is PlaylistLevel;
-
-			var playlistSong = level;
-			if (isPlaylistSong)
+			_currentLevelIsPlaylistSong = InstalledMods.BeatSaberPlaylistsLib && level.IsPlaylistLevel();
+			if (InstalledMods.BeatSaberPlaylistsLib && _currentLevelIsPlaylistSong)
 			{
-				level = VideoLoader.GetBeatmapLevelFromPlaylistSong(level);
+				level = level.GetLevelFromPlaylistIfAvailable();
 			}
 
 			PlaybackController.Instance.StopPreview(true);
@@ -562,8 +560,6 @@ namespace BeatSaberCinema
 			{
 				VideoLoader.SaveVideoConfig(_currentVideo);
 			}
-
-			_currentLevelIsPlaylistSong = isPlaylistSong;
 			_currentLevel = level;
 			if (_currentLevel == null)
 			{
@@ -573,7 +569,7 @@ namespace BeatSaberCinema
 				return;
 			}
 
-			_currentVideo = VideoLoader.GetConfigForLevel(isPlaylistSong ? playlistSong : _currentLevel, isPlaylistSong);
+			_currentVideo = VideoLoader.GetConfigForLevel(_currentLevel);
 
 			VideoLoader.SetupFileSystemWatcher(_currentLevel);
 			PlaybackController.Instance.SetSelectedLevel(_currentLevel, _currentVideo);


### PR DESCRIPTION
- Added reference to `BeatSaber.BeatmapEditor` for 1.39.0 
- Added `InstalledMods` - this centralizes all checks to see if certain soft dependencies are installed
- Now checks to see if BeatSaberPlaylistsLib is installed before trying to access any of its types, and will continue to work fine while BeatSaberPlaylistsLib is not installed. All references to BeatSaberPlaylistsLib are now in `PlaylistSongUtils` which reduces the amount of complex logic from the calling end
- Fixes the video menu not being reinitialized on internal restart by resetting the `VideoMenu.Instance` - this is more in-line with game logic since the menu should not persist through internal restart

<sub>P.S. remember to bump the manifest mod version before uploading to BM</sub>
