### PR TITLE
fix: unrecoverable error when delete song

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,5 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 .idea
+
+/ReleaseDir/

--- a/BeatSaberCinema.sln
+++ b/BeatSaberCinema.sln
@@ -1,16 +1,22 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36025.13
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BeatSaberCinema", "BeatSaberCinema\BeatSaberCinema.csproj", "{7E5A87BB-C142-4607-8E8D-E8A051C8DF32}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{7E5A87BB-C142-4607-8E8D-E8A051C8DF32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7E5A87BB-C142-4607-8E8D-E8A051C8DF32}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7E5A87BB-C142-4607-8E8D-E8A051C8DF32}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7E5A87BB-C142-4607-8E8D-E8A051C8DF32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E5A87BB-C142-4607-8E8D-E8A051C8DF32}.Debug|x64.ActiveCfg = Debug|x64
+		{7E5A87BB-C142-4607-8E8D-E8A051C8DF32}.Debug|x64.Build.0 = Debug|x64
+		{7E5A87BB-C142-4607-8E8D-E8A051C8DF32}.Release|x64.ActiveCfg = Release|x64
+		{7E5A87BB-C142-4607-8E8D-E8A051C8DF32}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/BeatSaberCinema/BeatSaberCinema.csproj
+++ b/BeatSaberCinema/BeatSaberCinema.csproj
@@ -10,22 +10,20 @@
 		<LangVersion>8</LangVersion>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+		<Platforms>x64</Platforms>
+		<PlatformTarget>x64</PlatformTarget>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
 	</PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-		<PlatformTarget>AnyCPU</PlatformTarget>
+	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>portable</DebugType>
 		<Optimize>false</Optimize>
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
-		<ErrorReport>prompt</ErrorReport>
-		<WarningLevel>4</WarningLevel>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-		<PlatformTarget>AnyCPU</PlatformTarget>
+	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<Optimize>true</Optimize>
-		<ErrorReport>prompt</ErrorReport>
-		<WarningLevel>4</WarningLevel>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/BeatSaberCinema/BeatSaberCinema.csproj
+++ b/BeatSaberCinema/BeatSaberCinema.csproj
@@ -7,7 +7,7 @@
 		<RootNamespace>BeatSaberCinema</RootNamespace>
 		<AssemblyName>BeatSaberCinema</AssemblyName>
 		<ModName>BeatSaberCinema</ModName>
-		<LangVersion>8</LangVersion>
+		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
 		<Platforms>x64</Platforms>

--- a/BeatSaberCinema/Screen/CustomVideoPlayer.cs
+++ b/BeatSaberCinema/Screen/CustomVideoPlayer.cs
@@ -38,7 +38,7 @@ namespace BeatSaberCinema
 		private bool _waitingForFadeOut;
 
 		internal event Action? stopped;
-		internal event Action OnError = delegate { };
+		internal event Action<string> OnError = delegate { };
 
 		public bool VideoEnded { get; private set; }
 
@@ -425,31 +425,7 @@ namespace BeatSaberCinema
 				return;
 			}
 
-			Log.Error("Video player error: " + message);
-			PlaybackController.Instance.StopPlayback();
-
-			var config = PlaybackController.Instance.VideoConfig;
-			if (config == null)
-			{
-				return;
-			}
-
-			config.UpdateDownloadState();
-			config.ErrorMessage = "Cinema playback error.";
-			if (message.Contains("Unexpected error code (10)") && SystemInfo.graphicsDeviceVendor == "NVIDIA")
-			{
-				config.ErrorMessage += " Try disabling NVIDIA Fast Sync.";
-			}
-			else if (message.Contains("It seems that the Microsoft Media Foundation is not installed on this machine"))
-			{
-				config.ErrorMessage += " Install Microsoft Media Foundation.";
-			}
-			else
-			{
-				config.ErrorMessage += " See logs for details.";
-			}
-
-			OnError.Invoke();
+			OnError.Invoke(message);
 		}
 
 		public float GetVideoAspectRatio()

--- a/BeatSaberCinema/Screen/CustomVideoPlayer.cs
+++ b/BeatSaberCinema/Screen/CustomVideoPlayer.cs
@@ -9,13 +9,13 @@ using UnityEngine.Video;
 
 namespace BeatSaberCinema
 {
-	public class CustomVideoPlayer: MonoBehaviour
+	public class CustomVideoPlayer : MonoBehaviour
 	{
 		//Initialized by Awake()
 		[NonSerialized] public VideoPlayer Player = null!;
 		private AudioSource _videoPlayerAudioSource = null!;
 		internal ScreenController screenController = null!;
-		private Renderer _screenRenderer  = null!;
+		private Renderer _screenRenderer = null!;
 		private RenderTexture _renderTexture = null!;
 		internal EasingController FadeController = null!;
 
@@ -38,6 +38,8 @@ namespace BeatSaberCinema
 		private bool _waitingForFadeOut;
 
 		internal event Action? stopped;
+		internal event Action OnError = delegate { };
+
 		public bool VideoEnded { get; private set; }
 
 		public Color ScreenColor
@@ -78,27 +80,10 @@ namespace BeatSaberCinema
 		{
 			CreateScreen();
 			_screenRenderer = screenController.GetRenderer();
-			_screenRenderer.material = new Material(GetShader()) {color = _screenColorOff};
+			_screenRenderer.material = new Material(GetShader()) { color = _screenColorOff };
 			_screenRenderer.material.enableInstancing = true;
 
-			Player = gameObject.AddComponent<VideoPlayer>();
-			Player.source = VideoSource.Url;
-			Player.renderMode = VideoRenderMode.RenderTexture;
-			_renderTexture = screenController.CreateRenderTexture();
-			_renderTexture.wrapMode = TextureWrapMode.Mirror;
-			Player.targetTexture = _renderTexture;
-
-			Player.playOnAwake = false;
-			Player.waitForFirstFrame = true;
-			Player.errorReceived += VideoPlayerErrorReceived;
-			Player.prepareCompleted += VideoPlayerPrepareComplete;
-			Player.started += VideoPlayerStarted;
-			Player.loopPointReached += VideoPlayerFinished;
-
-			//TODO PanStereo does not work as expected with this AudioSource. Panning fully to one side is still slightly audible in the other.
-			_videoPlayerAudioSource = gameObject.AddComponent<AudioSource>();
-			Player.audioOutputMode = VideoAudioOutputMode.AudioSource;
-			Player.SetTargetAudioSource(0, _videoPlayerAudioSource);
+			ResetInnerPlayer();
 			Mute();
 			screenController.SetScreensActive(false);
 			LoopVideo(false);
@@ -225,7 +210,7 @@ namespace BeatSaberCinema
 		public void SetDefaultMenuPlacement(float? width = null)
 		{
 			var placement = Placement.MenuPlacement;
-			placement.Width = width ?? placement.Height * (21f/9f);
+			placement.Width = width ?? placement.Height * (21f / 9f);
 			SetPlacement(placement);
 		}
 
@@ -242,7 +227,7 @@ namespace BeatSaberCinema
 			//So, we wait before the player renders its first frame and then set the color, making the switch invisible.
 			FadeIn();
 			_firstFrameStopwatch.Stop();
-			Log.Debug("Delay from Play() to first frame: "+_firstFrameStopwatch.ElapsedMilliseconds+" ms");
+			Log.Debug("Delay from Play() to first frame: " + _firstFrameStopwatch.ElapsedMilliseconds + " ms");
 			_firstFrameStopwatch.Reset();
 			screenController.SetAspectRatio(GetVideoAspectRatio());
 			Player.frameReady -= FirstFrameReady;
@@ -432,7 +417,7 @@ namespace BeatSaberCinema
 			}
 		}
 
-		private static void VideoPlayerErrorReceived(VideoPlayer source, string message)
+		private void VideoPlayerErrorReceived(VideoPlayer source, string message)
 		{
 			if (message == "Can't play movie []")
 			{
@@ -442,6 +427,7 @@ namespace BeatSaberCinema
 
 			Log.Error("Video player error: " + message);
 			PlaybackController.Instance.StopPlayback();
+
 			var config = PlaybackController.Instance.VideoConfig;
 			if (config == null)
 			{
@@ -449,11 +435,12 @@ namespace BeatSaberCinema
 			}
 
 			config.UpdateDownloadState();
-			config.ErrorMessage =  "Cinema playback error.";
+			config.ErrorMessage = "Cinema playback error.";
 			if (message.Contains("Unexpected error code (10)") && SystemInfo.graphicsDeviceVendor == "NVIDIA")
 			{
 				config.ErrorMessage += " Try disabling NVIDIA Fast Sync.";
-			} else if (message.Contains("It seems that the Microsoft Media Foundation is not installed on this machine"))
+			}
+			else if (message.Contains("It seems that the Microsoft Media Foundation is not installed on this machine"))
 			{
 				config.ErrorMessage += " Install Microsoft Media Foundation.";
 			}
@@ -462,7 +449,7 @@ namespace BeatSaberCinema
 				config.ErrorMessage += " See logs for details.";
 			}
 
-			VideoMenu.Instance?.SetupLevelDetailView(config);
+			OnError.Invoke();
 		}
 
 		public float GetVideoAspectRatio()
@@ -495,6 +482,41 @@ namespace BeatSaberCinema
 			{
 				screenController.SetSoftParent(parent);
 			}
+		}
+
+		private void ResetInnerPlayer()
+		{
+			if (Player != null)
+			{
+				Destroy(Player.gameObject);
+				PlaybackController.Create();
+				return;
+			}
+
+			Player = gameObject.AddComponent<VideoPlayer>();
+			Player.source = VideoSource.Url;
+			Player.renderMode = VideoRenderMode.RenderTexture;
+			if (_renderTexture == null)
+			{
+				_renderTexture = screenController.CreateRenderTexture();
+				_renderTexture.wrapMode = TextureWrapMode.Mirror;
+			}
+			Player.targetTexture = _renderTexture;
+
+			Player.playOnAwake = false;
+			Player.waitForFirstFrame = true;
+			Player.errorReceived += VideoPlayerErrorReceived;
+			Player.prepareCompleted += VideoPlayerPrepareComplete;
+			Player.started += VideoPlayerStarted;
+			Player.loopPointReached += VideoPlayerFinished;
+
+			//TODO PanStereo does not work as expected with this AudioSource. Panning fully to one side is still slightly audible in the other.
+			if (_videoPlayerAudioSource == null)
+			{
+				_videoPlayerAudioSource = gameObject.AddComponent<AudioSource>();
+			}
+			Player.audioOutputMode = VideoAudioOutputMode.AudioSource;
+			Player.SetTargetAudioSource(0, _videoPlayerAudioSource);
 		}
 	}
 }

--- a/BeatSaberCinema/Screen/LightController.cs
+++ b/BeatSaberCinema/Screen/LightController.cs
@@ -15,7 +15,6 @@ namespace BeatSaberCinema
 		private AsyncGPUReadbackRequest? _readbackRequest;
 		private readonly Stopwatch _readbackRequestStopwatch = new Stopwatch();
 
-		private CustomVideoPlayer _customVideoPlayer = null!;
 		private GameObject _lightGameObject = null!;
 		private DirectionalLight _light = null!;
 		private List<RenderTexture> _downscaleTextures = null!;
@@ -50,15 +49,15 @@ namespace BeatSaberCinema
 
 		private void OnEnable()
 		{
-			_customVideoPlayer = PlaybackController.Instance.VideoPlayer;
+			var player = PlaybackController.Instance.VideoPlayer;
 			if (_lightGameObject == null)
 			{
-				CreateLight();
+				_lightGameObject = CreateLight();
 			}
 
-			_customVideoPlayer.Player.frameReady += ProcessFrame;
-			_customVideoPlayer.stopped += VideoStopped;
-			_customVideoPlayer.FadeController.EasingUpdate += OnFadeUpdate;
+			player.Player.frameReady += ProcessFrame;
+			player.stopped += VideoStopped;
+			player.FadeController.EasingUpdate += OnFadeUpdate;
 			Events.LevelSelected += OnLevelSelected;
 			BSEvents.menuSceneLoaded += OnMenuSceneLoaded;
 			BSEvents.lateMenuSceneLoadedFresh += OnMenuSceneLoadedFresh;
@@ -66,9 +65,10 @@ namespace BeatSaberCinema
 
 		private void OnDisable()
 		{
-			_customVideoPlayer.Player.frameReady -= ProcessFrame;
-			_customVideoPlayer.stopped -= VideoStopped;
-			_customVideoPlayer.FadeController.EasingUpdate -= OnFadeUpdate;
+			var player = PlaybackController.Instance.VideoPlayer;
+			player.Player.frameReady -= ProcessFrame;
+			player.stopped -= VideoStopped;
+			player.FadeController.EasingUpdate -= OnFadeUpdate;
 			Events.LevelSelected -= OnLevelSelected;
 			BSEvents.menuSceneLoaded -= OnMenuSceneLoaded;
 			BSEvents.lateMenuSceneLoadedFresh -= OnMenuSceneLoadedFresh;
@@ -142,6 +142,11 @@ namespace BeatSaberCinema
 
 		internal void Enable()
 		{
+			if (_lightGameObject == null)
+			{
+				_lightGameObject = CreateLight();
+			}
+
 			_lightGameObject.SetActive(true);
 		}
 
@@ -157,20 +162,23 @@ namespace BeatSaberCinema
 			UpdateColor(_color);
 		}
 
-		private void CreateLight()
+		private GameObject CreateLight()
 		{
-			var screen = _customVideoPlayer.screenController.Screens[0];
-			_lightGameObject = new GameObject("CinemaDirectionalLight");
-			_lightGameObject.transform.parent = screen.transform;
-			_lightGameObject.transform.forward = -screen.transform.forward;
-			var euler = _lightGameObject.transform.eulerAngles;
+			var player = PlaybackController.Instance.VideoPlayer;
+			var screen = player.screenController.Screens[0];
+			var lightGameObject = new GameObject("CinemaDirectionalLight");
+			lightGameObject.transform.parent = screen.transform;
+			lightGameObject.transform.forward = -screen.transform.forward;
+			var euler = lightGameObject.transform.eulerAngles;
 			euler.x = LIGHT_X_ROTATION;
-			_lightGameObject.transform.eulerAngles = euler;
+			lightGameObject.transform.eulerAngles = euler;
 
-			_light = _lightGameObject.AddComponent<DirectionalLight>();
+			_light = lightGameObject.AddComponent<DirectionalLight>();
 			_light.radius = LIGHT_RADIUS;
 			_light.intensity = DIRECTIONAL_LIGHT_INTENSITY_MENU;
 			_light.color = Color.black;
+
+			return lightGameObject;
 		}
 
 		private void VideoStopped()
@@ -206,8 +214,9 @@ namespace BeatSaberCinema
 
 		private void UpdateColor(Color color)
 		{
+			var player = PlaybackController.Instance.VideoPlayer;
 			_color = color;
-			_light.color = _color * _customVideoPlayer.ScreenColor;
+			_light.color = _color * player.ScreenColor;
 
 			if (Util.GetEnvironmentName() != "MainMenu")
 			{
@@ -215,7 +224,7 @@ namespace BeatSaberCinema
 			}
 
 			//Darken the base menu lighting
-			var baseColor = MenuColorPatch.BaseColor * (Color.white - (_customVideoPlayer.ScreenColor * MENU_DARKENING_INTENSITY));
+			var baseColor = MenuColorPatch.BaseColor * (Color.white - (player.ScreenColor * MENU_DARKENING_INTENSITY));
 			baseColor.a = 1;
 
 			if (_menuFloorLight != null)

--- a/BeatSaberCinema/Screen/LightController.cs
+++ b/BeatSaberCinema/Screen/LightController.cs
@@ -50,10 +50,6 @@ namespace BeatSaberCinema
 		private void OnEnable()
 		{
 			var player = PlaybackController.Instance.VideoPlayer;
-			if (_lightGameObject == null)
-			{
-				_lightGameObject = CreateLight();
-			}
 
 			player.Player.frameReady += ProcessFrame;
 			player.stopped += VideoStopped;
@@ -95,37 +91,40 @@ namespace BeatSaberCinema
 
 		internal void OnGameSceneLoaded()
 		{
-			var euler = _lightGameObject.transform.eulerAngles;
+			var lightObject = GetOrCreateLight();
+			var euler = lightObject.transform.eulerAngles;
 			euler.x = LIGHT_X_ROTATION;
-			_light.intensity = DIRECTIONAL_LIGHT_INTENSITY_GAMEPLAY;
+			var light = GetOrAddDirectionalLight();
+			light.intensity = DIRECTIONAL_LIGHT_INTENSITY_GAMEPLAY;
 
 			switch (Util.GetEnvironmentName())
 			{
 				case "BillieEnvironment":
 					//Tone down lighting on this env a bit, since clouds get pretty bright
-					_light.intensity = 1.2f;
+					light.intensity = 1.2f;
 					euler.x = 42;
 					break;
 				case "BTSEnvironment":
 					//Same as with Billie, clouds are too bright
-					_light.intensity = 1.6f;
+					light.intensity = 1.6f;
 					euler.x = 55;
 					break;
 				case "LizzoEnvironment":
 					//Background objects behind player too bright
-					_light.intensity = 1f;
+					light.intensity = 1f;
 					euler.x = 42;
 					break;
 			}
-			_lightGameObject.transform.eulerAngles = euler;
+			lightObject.transform.eulerAngles = euler;
 		}
 
 		private void OnMenuSceneLoaded()
 		{
-			var euler = _lightGameObject.transform.eulerAngles;
+			var lightObject = GetOrCreateLight();
+			var euler = lightObject.transform.eulerAngles;
 			euler.x = LIGHT_X_ROTATION;
-			_lightGameObject.transform.eulerAngles = euler;
-			_light.intensity = DIRECTIONAL_LIGHT_INTENSITY_MENU;
+			lightObject.transform.eulerAngles = euler;
+			GetOrAddDirectionalLight().intensity = DIRECTIONAL_LIGHT_INTENSITY_MENU;
 		}
 
 		private void OnMenuSceneLoadedFresh(ScenesTransitionSetupDataSO scenesTransitionSetupDataSo)
@@ -142,12 +141,7 @@ namespace BeatSaberCinema
 
 		internal void Enable()
 		{
-			if (_lightGameObject == null)
-			{
-				_lightGameObject = CreateLight();
-			}
-
-			_lightGameObject.SetActive(true);
+			GetOrCreateLight().SetActive(true);
 		}
 
 		private void GetMenuReferences()
@@ -162,6 +156,16 @@ namespace BeatSaberCinema
 			UpdateColor(_color);
 		}
 
+		private GameObject GetOrCreateLight()
+		{
+			if (_lightGameObject == null)
+			{
+				_lightGameObject = CreateLight();
+			}
+
+			return _lightGameObject;
+		}
+
 		private GameObject CreateLight()
 		{
 			var player = PlaybackController.Instance.VideoPlayer;
@@ -173,12 +177,26 @@ namespace BeatSaberCinema
 			euler.x = LIGHT_X_ROTATION;
 			lightGameObject.transform.eulerAngles = euler;
 
-			_light = lightGameObject.AddComponent<DirectionalLight>();
-			_light.radius = LIGHT_RADIUS;
-			_light.intensity = DIRECTIONAL_LIGHT_INTENSITY_MENU;
-			_light.color = Color.black;
-
 			return lightGameObject;
+		}
+
+		private DirectionalLight GetOrAddDirectionalLight()
+		{
+			if (_light == null)
+			{
+				_light = AddDirectionalLight();
+			}
+
+			return _light;
+		}
+
+		private DirectionalLight AddDirectionalLight()
+		{
+			var light = GetOrCreateLight().AddComponent<DirectionalLight>();
+			light.radius = LIGHT_RADIUS;
+			light.intensity = DIRECTIONAL_LIGHT_INTENSITY_MENU;
+			light.color = Color.black;
+			return light;
 		}
 
 		private void VideoStopped()
@@ -216,7 +234,8 @@ namespace BeatSaberCinema
 		{
 			var player = PlaybackController.Instance.VideoPlayer;
 			_color = color;
-			_light.color = _color * player.ScreenColor;
+			var light = GetOrAddDirectionalLight();
+			light.color = _color * player.ScreenColor;
 
 			if (Util.GetEnvironmentName() != "MainMenu")
 			{
@@ -224,19 +243,19 @@ namespace BeatSaberCinema
 			}
 
 			//Darken the base menu lighting
-			var baseColor = MenuColorPatch.BaseColor * (Color.white - (player.ScreenColor * MENU_DARKENING_INTENSITY));
+			var baseColor = MenuColorPatch.BaseColor * (Color.white - player.ScreenColor * MENU_DARKENING_INTENSITY);
 			baseColor.a = 1;
 
 			if (_menuFloorLight != null)
 			{
-				var colors = new[] { baseColor, (_light.color * MENU_FLOOR_INTENSITY) };
+				var colors = new[] { baseColor, light.color * MENU_FLOOR_INTENSITY };
 				var combinedColor = AddColors(colors);
 				_menuFloorLight.ColorWasSet(combinedColor);
 			}
 
 			if (_menuFogRing != null)
 			{
-				var colors = new[] { baseColor, (_light.color * MENU_FOG_INTENSITY) };
+				var colors = new[] { baseColor, light.color * MENU_FOG_INTENSITY };
 				var combinedColor = AddColors(colors);
 				_menuFogRing.ColorWasSet(combinedColor);
 			}

--- a/BeatSaberCinema/Screen/PlaybackController.cs
+++ b/BeatSaberCinema/Screen/PlaybackController.cs
@@ -1132,9 +1132,19 @@ namespace BeatSaberCinema
 			}
 		}
 
-		private void RetryIfNotSameVideo()
+		private void RetryIfNotSameVideo(string message)
 		{
+			var songMayBeDeleted = message.Contains("VideoPlayer cannot play url");
 			var isRetryable = _lastErrorVideoConfig != VideoConfig;
+			if (songMayBeDeleted && isRetryable)
+			{
+				Log.Info($"Song may be deleted, retry by error: {message}");
+			}
+			else
+			{
+				Log.Error($"Video player error: {message}");
+			}
+
 			if (isRetryable)
 			{
 				_lastErrorVideoConfig = VideoConfig;
@@ -1147,11 +1157,32 @@ namespace BeatSaberCinema
 				return;
 			}
 
-			if (_lastErrorVideoConfig != null)
+			StopPlayback();
+
+			if (VideoConfig != null)
 			{
-				VideoMenu.Instance?.SetupLevelDetailView(_lastErrorVideoConfig);
-				return;
+				DisplayError(message, VideoConfig);
 			}
+		}
+
+		private void DisplayError(string message, VideoConfig config)
+		{
+			config.UpdateDownloadState();
+			config.ErrorMessage = "Cinema playback error.";
+			if (message.Contains("Unexpected error code (10)") && SystemInfo.graphicsDeviceVendor == "NVIDIA")
+			{
+				config.ErrorMessage += " Try disabling NVIDIA Fast Sync.";
+			}
+			else if (message.Contains("It seems that the Microsoft Media Foundation is not installed on this machine"))
+			{
+				config.ErrorMessage += " Install Microsoft Media Foundation.";
+			}
+			else
+			{
+				config.ErrorMessage += " See logs for details.";
+			}
+
+			VideoMenu.Instance?.SetupLevelDetailView(config);
 		}
 
 		private void ResetPlayer()

--- a/BeatSaberCinema/Screen/PlaybackController.cs
+++ b/BeatSaberCinema/Screen/PlaybackController.cs
@@ -11,7 +11,7 @@ using UnityEngine.Video;
 
 namespace BeatSaberCinema
 {
-	public class PlaybackController: MonoBehaviour
+	public class PlaybackController : MonoBehaviour
 	{
 		public enum Scene { SoloGameplay, MultiplayerGameplay, Menu, Other }
 		private Scene _activeScene = Scene.Other;
@@ -141,7 +141,7 @@ namespace BeatSaberCinema
 
 			ResyncVideo();
 			VideoPlayer.Player.frameReady += PlayerStartedAfterResync;
-			Log.Debug("Applying offset: "+offset);
+			Log.Debug("Applying offset: " + offset);
 		}
 
 		private void PlayerStartedAfterResync(VideoPlayer player, long frame)
@@ -242,7 +242,7 @@ namespace BeatSaberCinema
 			if (frame % 120 == 0)
 			{
 				Log.Debug("Frame: " + frame + " - Player: " + Util.FormatFloat((float) playerTime) + " - AudioSource: " +
-				          Util.FormatFloat(audioSourceTime) + " - Error (ms): " + Math.Round(error * 1000));
+						Util.FormatFloat(audioSourceTime) + " - Error (ms): " + Math.Round(error * 1000));
 			}
 
 			if (VideoConfig.endVideoAt.HasValue)
@@ -424,7 +424,7 @@ namespace BeatSaberCinema
 			else
 			{
 				VideoPlayer.VolumeScale = _settingsManager.settings.audio.volume;
-	            VideoPlayer.screenController.OnGameSceneLoadedFresh();
+				VideoPlayer.screenController.OnGameSceneLoadedFresh();
 			}
 		}
 
@@ -668,7 +668,7 @@ namespace BeatSaberCinema
 
 			if (VideoConfig == null || !VideoConfig.IsPlayable)
 			{
-				Log.Debug("No video configured or video is not playable: "+VideoConfig?.VideoPath);
+				Log.Debug("No video configured or video is not playable: " + VideoConfig?.VideoPath);
 
 				if (SettingsStore.Instance.CoverEnabled && (VideoConfig?.forceEnvironmentModifications == null || VideoConfig.forceEnvironmentModifications == false))
 				{
@@ -845,7 +845,7 @@ namespace BeatSaberCinema
 				if (BS_Utils.Plugin.LevelData.GameplayCoreSceneSetupData?.practiceSettings != null)
 				{
 					songSpeed = BS_Utils.Plugin.LevelData.GameplayCoreSceneSetupData.practiceSettings.songSpeedMul;
-					if ((totalOffset+startTime) < 0)
+					if ((totalOffset + startTime) < 0)
 					{
 						totalOffset /= (songSpeed * VideoConfig.PlaybackSpeed);
 					}
@@ -929,7 +929,7 @@ namespace BeatSaberCinema
 		//TODO Using a stopwatch will not work properly when seeking in the map (e.g. IntroSkip, PracticePlugin)
 		private IEnumerator PlayVideoDelayedCoroutine(float delayStartTime)
 		{
-			Log.Debug("Waiting for "+delayStartTime+" seconds before playing video");
+			Log.Debug("Waiting for " + delayStartTime + " seconds before playing video");
 			_playbackDelayStopwatch ??= new Stopwatch();
 			_playbackDelayStopwatch.Start();
 			VideoPlayer.Pause();
@@ -937,7 +937,7 @@ namespace BeatSaberCinema
 			VideoPlayer.Player.time = 0;
 			var ticksUntilStart = (delayStartTime) * TimeSpan.TicksPerSecond;
 			yield return new WaitUntil(() => _playbackDelayStopwatch.ElapsedTicks >= ticksUntilStart);
-			Log.Debug("Elapsed ms: "+_playbackDelayStopwatch.ElapsedMilliseconds);
+			Log.Debug("Elapsed ms: " + _playbackDelayStopwatch.ElapsedMilliseconds);
 			_playbackDelayStopwatch.Stop();
 			_playbackDelayStopwatch.Reset();
 
@@ -1002,7 +1002,7 @@ namespace BeatSaberCinema
 				timeout.Stop();
 				if (timeout.HasTimedOut && Util.IsFileLocked(videoFileInfo))
 				{
-					Log.Warn("Video file locked: "+videoPath);
+					Log.Warn("Video file locked: " + videoPath);
 				}
 			}
 

--- a/BeatSaberCinema/Screen/PlaybackController.cs
+++ b/BeatSaberCinema/Screen/PlaybackController.cs
@@ -33,6 +33,8 @@ namespace BeatSaberCinema
 		private DateTime _audioSourceStartTime;
 		private float _offsetAfterPrepare;
 		private Stopwatch? _playbackDelayStopwatch;
+		private GameObject? _videoPlayerGameObject;
+		private VideoConfig? _lastErrorVideoConfig;
 
 		public VideoConfig? VideoConfig { get; private set; }
 
@@ -67,11 +69,9 @@ namespace BeatSaberCinema
 				return;
 			}
 			Instance = this;
+			ResetPlayer();
 
-			VideoPlayer = gameObject.AddComponent<CustomVideoPlayer>();
 			LightController = gameObject.AddComponent<LightController>();
-			VideoPlayer.Player.frameReady += FrameReady;
-			VideoPlayer.Player.sendFrameReadyEvents = true;
 			BSEvents.gameSceneActive += GameSceneActive;
 			BSEvents.gameSceneLoaded += GameSceneLoaded;
 			BSEvents.songPaused += PauseVideo;
@@ -79,7 +79,6 @@ namespace BeatSaberCinema
 			BSEvents.lateMenuSceneLoadedFresh += OnMenuSceneLoadedFresh;
 			BSEvents.menuSceneLoaded += OnMenuSceneLoaded;
 			VideoLoader.ConfigChanged += OnConfigChanged;
-			VideoPlayer.Player.prepareCompleted += OnPrepareComplete;
 			Events.DifficultySelected += DifficultySelected;
 			DontDestroyOnLoad(gameObject);
 
@@ -1131,6 +1130,53 @@ namespace BeatSaberCinema
 			{
 				Log.Debug($"Not playing song preview, because delay was too long. Remaining preview time: {_previewTimeRemaining}");
 			}
+		}
+
+		private void RetryIfNotSameVideo()
+		{
+			var isRetryable = _lastErrorVideoConfig != VideoConfig;
+			if (isRetryable)
+			{
+				_lastErrorVideoConfig = VideoConfig;
+				if (VideoConfig != null)
+				{
+					VideoConfig.ErrorMessage = null;
+				}
+				ResetPlayer();
+
+				return;
+			}
+
+			if (_lastErrorVideoConfig != null)
+			{
+				VideoMenu.Instance?.SetupLevelDetailView(_lastErrorVideoConfig);
+				return;
+			}
+		}
+
+		private void ResetPlayer()
+		{
+			Destroy(_videoPlayerGameObject);
+
+			var playerGameObject = new GameObject("CinemaVideoPlayer");
+			VideoPlayer = CreateVideoPlayer(playerGameObject);
+			DontDestroyOnLoad(playerGameObject);
+			_videoPlayerGameObject = playerGameObject;
+
+			if (VideoConfig != null)
+			{
+				PrepareVideo(VideoConfig);
+			}
+		}
+
+		private CustomVideoPlayer CreateVideoPlayer(GameObject gameObject)
+		{
+			var videoPlayer = gameObject.AddComponent<CustomVideoPlayer>();
+			videoPlayer.Player.frameReady += FrameReady;
+			videoPlayer.Player.sendFrameReadyEvents = true;
+			videoPlayer.Player.prepareCompleted += OnPrepareComplete;
+			videoPlayer.OnError += RetryIfNotSameVideo;
+			return videoPlayer;
 		}
 	}
 }


### PR DESCRIPTION
### Background

Cinema mod would consistently fail to play after deleting a song that was currently being played.

### Changes

* Moved `CustomVideoPlayer` to a separate GameObject.
* The GameObject is now recreated when an error occurs to ensure proper recovery.

### How to Test

1. Select a cinema song from the in-game menu.
2. Delete the selected song’s folder (this was done in-game; the deletion feature may have been added by a mod).
3. Select, play a different cinema song and verify that it plays without any errors.